### PR TITLE
Anonymous child docs shouldn't be nested in field

### DIFF
--- a/src/QueryType/Update/RequestBuilder.php
+++ b/src/QueryType/Update/RequestBuilder.php
@@ -270,7 +270,13 @@ class RequestBuilder extends BaseRequestBuilder
         if (\is_array($value)) {
             $nestedXml = '';
             foreach ($value as $multival) {
-                if (\is_array($multival)) {
+                if (\is_array($multival) && $key === '_childDocuments_') {
+                    $xml .= '<doc>';
+                    foreach ($multival as $k => $v) {
+                        $xml .= $this->buildFieldsXml($k, $boost, $v, $modifier);
+                    }
+                    $xml .= '</doc>';
+                } elseif (\is_array($multival)) {
                     $nestedXml .= '<doc';
                     $nestedXml .= $this->attrib('update', $modifier);
                     $nestedXml .= '>';
@@ -286,7 +292,7 @@ class RequestBuilder extends BaseRequestBuilder
                     $xml .= $this->buildFieldXml($key, $boost, $multival, $modifier);
                 }
             }
-            if (!empty($nestedXml)) {
+            if (!empty($nestedXml) && $key !== '_childDocuments_') {
                 $xml .= '<field name="'.$key.'">'.$nestedXml.'</field>';
             }
         } else {

--- a/src/QueryType/Update/RequestBuilder.php
+++ b/src/QueryType/Update/RequestBuilder.php
@@ -292,7 +292,7 @@ class RequestBuilder extends BaseRequestBuilder
                     $xml .= $this->buildFieldXml($key, $boost, $multival, $modifier);
                 }
             }
-            if (!empty($nestedXml) && $key !== '_childDocuments_') {
+            if (!empty($nestedXml) && '_childDocuments_' !== $key) {
                 $xml .= '<field name="'.$key.'">'.$nestedXml.'</field>';
             }
         } else {

--- a/src/QueryType/Update/RequestBuilder.php
+++ b/src/QueryType/Update/RequestBuilder.php
@@ -270,7 +270,7 @@ class RequestBuilder extends BaseRequestBuilder
         if (\is_array($value)) {
             $nestedXml = '';
             foreach ($value as $multival) {
-                if (\is_array($multival) && $key === '_childDocuments_') {
+                if (\is_array($multival) && '_childDocuments_' === $key) {
                     $xml .= '<doc>';
                     foreach ($multival as $k => $v) {
                         $xml .= $this->buildFieldsXml($k, $boost, $v, $modifier);


### PR DESCRIPTION
Hey @davchs 

You had a back for backwards compatibility for anonymous child documents. I happen to have an old solr 6 and new solr 8 index to update, one with anonymous child documents and one with named child documents.

This patch makes it work fine for both in this PR https://github.com/solariumphp/solarium/pull/872